### PR TITLE
Pin certifi to version compatible with 2023 releases

### DIFF
--- a/requirementsbackup.txt
+++ b/requirementsbackup.txt
@@ -10,7 +10,7 @@ babel==2.17.0
 beautifulsoup4==4.13.4
 bleach==6.2.0
 blinker==1.9.0
-certifi==2025.8.3
+certifi==2023.11.17
 cffi==1.17.1
 charset-normalizer==3.4.3
 click==8.1.8


### PR DESCRIPTION
## Summary
- Pin certifi dependency to 2023.11.17 to satisfy supported range

## Testing
- `pip install -r requirementsbackup.txt` *(fails: conflicting dependencies)*
- `python -m pytest` *(fails: pyenv: version '3.11.8' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aefeaab07883259729b0101a48de61