### PR TITLE
Improve chart highlighting and zoom behavior

### DIFF
--- a/frontend/src/components/RatingChart.jsx
+++ b/frontend/src/components/RatingChart.jsx
@@ -7,20 +7,16 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
-  ReferenceLine,
-  Brush,
   ReferenceArea,
 } from "recharts";
 
-export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }) {
+export default function RatingChart({ teams, selectedYear, selectedYearsByTeam, highlightedTeams = [], onToggleTeam, showTooltip = true }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [data, setData] = useState([]);
   const [displayedTeams, setDisplayedTeams] = useState([]);
   const [highlightDataByTeam, setHighlightDataByTeam] = useState({});
-  const [activeTeam, setActiveTeam] = useState(null);
   const [refAreaLeft, setRefAreaLeft] = useState(null);
   const [refAreaRight, setRefAreaRight] = useState(null);
   const [xDomain, setXDomain] = useState(["auto", "auto"]);
@@ -53,17 +49,6 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
     if (selectedYear != null) return [Number(selectedYear)];
     return [];
   };
-
-  const yearToTeams = React.useMemo(() => {
-    const map = new Map();
-    displayedTeams.forEach((team, idx) => {
-      yearsForTeam(team).forEach((y) => {
-        if (!map.has(y)) map.set(y, []);
-        map.get(y).push({ team, idx });
-      });
-    });
-    return map;
-  }, [displayedTeams, selectedYearsByTeam, selectedYear]);
 
   const isHighlightedYear = (yearNum) => {
     if (yearNum == null || selectedYearsSet.size === 0) return false;
@@ -187,13 +172,13 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
     );
   };
 
-  const CustomTooltip = ({ active, label, payload, activeTeam }) => {
+  const CustomTooltip = ({ active, label, payload }) => {
     if (!active || !payload || payload.length === 0) return null;
     let filtered = payload.filter(
       (p) => !p?.payload?.__isHighlight && p.value != null
     );
-    if (activeTeam) {
-      filtered = filtered.filter((p) => p.name === activeTeam);
+    if (highlightedTeams.length > 0) {
+      filtered = filtered.filter((p) => highlightedTeams.includes(p.name));
     }
     const map = new Map();
     for (const p of filtered) {
@@ -222,10 +207,6 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
         </ul>
       </div>
     );
-  };
-
-  const handleLineClick = (team) => {
-    setActiveTeam((prev) => (prev === team ? null : team));
   };
 
   const onMouseDown = (e) => {
@@ -285,105 +266,45 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
               x2={refAreaRight}
               ifOverflow="extendDomain"
               strokeOpacity={0.3}
+              fillOpacity={0.1}
             />
-            {false && uniqueTeams.map((team, idx) => (
-              yearsForTeam(team).map((y) => {
-                const group = yearToTeams.get(y) || [];
-                const count = group.length;
-                const conflictIdx = Math.max(0, group.findIndex(g => g.team === team));
-                const px = count > 1 ? (conflictIdx - (count - 1) / 2) * 7 : 0;
-                return (
-                  <ReferenceLine
-                    key={`ref-${team}-${y}`}
-                    x={y}
-                    ifOverflow="extendDomain"
-                    stroke={baseTeamColor(idx)}
-                    strokeDasharray="4 4"
-                    strokeWidth={2}
-                    label={count > 1 ? {
-                      position: "top",
-                      content: (props) => {
-                        const { viewBox } = props || {};
-                        if (!viewBox) return null;
-                        const x = (viewBox.x || 0) + px;
-                        const yTop = (viewBox.y || 0);
-                        return (
-                          <g>
-                            <line x1={x} y1={yTop} x2={x} y2={yTop + 12} stroke={baseTeamColor(idx)} strokeWidth={3} />
-                          </g>
-                        );
-                      }
-                    } : undefined}
-                  />
-                );
-              })
-            ))}
             <XAxis
               dataKey="date"
               type="number"
               domain={xDomain}
               tick={<YearAwareTick />}
               allowDuplicatedCategory={false}
+              allowDataOverflow
             />
             <YAxis
               domain={yDomain}
               tickFormatter={(val) => val.toFixed(2)}
               allowDecimals={true}
+              allowDataOverflow
             />
-            <Tooltip content={<CustomTooltip activeTeam={activeTeam} />} />
-            <Legend
-              content={() => (
-                <ul
-                  style={{ display: "flex", gap: 16, listStyle: "none", padding: 0, margin: 0 }}
-                >
-                  {uniqueTeams.map((team, idx) => (
-                    <li
-                      key={team}
-                      onClick={() => handleLineClick(team)}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
-                        cursor: "pointer",
-                        opacity:
-                          activeTeam && activeTeam !== team ? 0.3 : 1,
-                      }}
-                    >
-                      <svg width="14" height="14" viewBox="0 0 14 14">
-                        <line
-                          x1="1"
-                          y1="7"
-                          x2="13"
-                          y2="7"
-                          stroke={baseTeamColor(idx)}
-                          strokeWidth="3"
-                          strokeOpacity={
-                            activeTeam && activeTeam !== team ? 0.3 : 1
-                          }
-                        />
-                      </svg>
-                      <span>{team}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            />
-            {uniqueTeams.map((team, idx) => (
-              <Line
-                key={team}
-                type="monotone"
-                dataKey={team}
-                stroke={baseTeamColor(idx)}
-                strokeWidth={activeTeam === team ? 4 : 2}
-                strokeOpacity={activeTeam && activeTeam !== team ? 0.1 : 1}
-                dot={false}
-                onClick={() => handleLineClick(team)}
-                cursor="pointer"
-              />
-            ))}
+            {showTooltip && <Tooltip content={<CustomTooltip />} />}
+            {uniqueTeams.map((team, idx) => {
+              const highlighted = highlightedTeams.includes(team);
+              const faded = highlightedTeams.length > 0 && !highlighted;
+              return (
+                <Line
+                  key={team}
+                  type="monotone"
+                  dataKey={team}
+                  stroke={baseTeamColor(idx)}
+                  strokeWidth={highlighted ? 4 : 2}
+                  strokeOpacity={faded ? 0.1 : 1}
+                  dot={false}
+                  onClick={() => onToggleTeam && onToggleTeam(team)}
+                  cursor="pointer"
+                />
+              );
+            })}
             {uniqueTeams.flatMap((team, idx) => {
               const arr = highlightDataByTeam[team];
               if (!arr || arr.length === 0) return [];
+              const highlighted = highlightedTeams.includes(team);
+              const faded = highlightedTeams.length > 0 && !highlighted;
               return arr.map(({ year, data }) => (
                 <Line
                   key={`${team}__highlight__${year}`}
@@ -391,8 +312,8 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
                   dataKey={team}
                   data={data}
                   stroke={highlightTeamColor(idx)}
-                  strokeWidth={activeTeam === team ? 6 : 5}
-                  strokeOpacity={activeTeam && activeTeam !== team ? 0.05 : 1}
+                  strokeWidth={highlighted ? 6 : 5}
+                  strokeOpacity={faded ? 0.05 : 1}
                   isAnimationActive={false}
                   dot={{ r: 5 }}
                   activeDot={false}
@@ -400,12 +321,11 @@ export default function RatingChart({ teams, selectedYear, selectedYearsByTeam }
                   strokeLinecap="round"
                   legendType="none"
                   name={undefined}
-                  onClick={() => handleLineClick(team)}
+                  onClick={() => onToggleTeam && onToggleTeam(team)}
                   cursor="pointer"
                 />
               ));
             })}
-            <Brush dataKey="date" height={20} stroke="#8884d8" />
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/frontend/src/pages/GamePrediction.jsx
+++ b/frontend/src/pages/GamePrediction.jsx
@@ -359,7 +359,11 @@ export default function GamePrediction() {
           </div>
         )}
 
-        <RatingChart teams={[homeTeam, awayTeam].filter(Boolean)} selectedYearsByTeam={selectedYearsByTeam} />
+        <RatingChart
+          teams={[homeTeam, awayTeam].filter(Boolean)}
+          selectedYearsByTeam={selectedYearsByTeam}
+          showTooltip={false}
+        />
 
         {/* Prediction result display */}
         <div className="bg-white border rounded-2xl p-4 shadow-sm">

--- a/frontend/src/pages/HistoricalRanking.jsx
+++ b/frontend/src/pages/HistoricalRanking.jsx
@@ -4,14 +4,15 @@ import { getTeams } from "../lib/api";
 
 /**
  * HistoricalRanking page
- * Allows users to toggle NBA teams and view their Elo ratings over time.
- * - All teams are selected by default once loaded.
- * - Users can select/unselect individual teams or use Select All / Unselect All.
- * - Below the controls, a RatingChart visualises the ratings for selected teams.
+ * Renders all NBA teams and allows users to highlight any subset.
+ * - All teams are always shown in the chart.
+ * - Clicking a team button toggles whether that team is highlighted.
+ * - Users can quickly highlight or clear all teams with the bulk actions.
+ * - Below the controls, a RatingChart visualises the ratings with highlighted teams emphasized.
  */
 export default function HistoricalRanking() {
   const [teams, setTeams] = useState([]); // All teams from API
-  const [selected, setSelected] = useState([]); // Currently selected teams
+  const [highlighted, setHighlighted] = useState([]); // Highlighted teams
   const [loadingTeams, setLoadingTeams] = useState(true);
   const [error, setError] = useState("");
 
@@ -23,8 +24,6 @@ export default function HistoricalRanking() {
         const list = await getTeams();
         if (!active) return;
         setTeams(list);
-        // Select all teams initially
-        setSelected(list);
       } catch (e) {
         if (active) setError(e.message || "Failed to load teams");
       } finally {
@@ -38,27 +37,27 @@ export default function HistoricalRanking() {
   }, []);
 
   function toggleTeam(team) {
-    setSelected((prev) =>
+    setHighlighted((prev) =>
       prev.includes(team) ? prev.filter((t) => t !== team) : [...prev, team]
     );
   }
 
-  function selectAll() {
-    setSelected(teams);
+  function highlightAll() {
+    setHighlighted(teams);
   }
 
-  function unselectAll() {
-    setSelected([]);
+  function clearHighlights() {
+    setHighlighted([]);
   }
 
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold">Historical Ratings</h2>
 
-      {/* Team toggle buttons */}
+      {/* Team highlight buttons */}
       <div className="flex flex-wrap gap-2">
         {teams.map((team) => {
-          const active = selected.includes(team);
+          const active = highlighted.includes(team);
           return (
             <button
               key={team}
@@ -80,15 +79,15 @@ export default function HistoricalRanking() {
         <div className="space-x-2">
           <button
             className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300"
-            onClick={selectAll}
+            onClick={highlightAll}
           >
-            Select All
+            Highlight All
           </button>
           <button
             className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300"
-            onClick={unselectAll}
+            onClick={clearHighlights}
           >
-            Unselect All
+            Clear Highlights
           </button>
         </div>
       )}
@@ -98,7 +97,7 @@ export default function HistoricalRanking() {
         {loadingTeams && <p>Loading teams...</p>}
         {error && <p className="text-red-600">Error: {error}</p>}
         {!loadingTeams && !error && (
-          <RatingChart teams={selected} />
+          <RatingChart teams={teams} highlightedTeams={highlighted} onToggleTeam={toggleTeam} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove legacy brush zoom in favor of drag-to-select zoom
- Allow disabling tooltips; hide them on GamePrediction chart

## Testing
- `npm --prefix frontend run lint` *(fails: 9 errors, 3 warnings in untouched files)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af0e519d388325949fd793852c3294